### PR TITLE
Adds throwing secure storage reads for transparency

### DIFF
--- a/Sources/OktaOidc/Common/OktaOidcError.swift
+++ b/Sources/OktaOidc/Common/OktaOidcError.swift
@@ -41,6 +41,8 @@ public enum OktaOidcError: CustomNSError {
     case unableToGetAuthCode
     case unableToOpenBrowser // macOS specific
     
+    case errorUnarchivingStateManager(String)
+    
     public static var errorDomain: String = "\(Self.self)"
     
     /// Most of errors returns the general error code.
@@ -132,7 +134,8 @@ extension OktaOidcError: LocalizedError {
             return NSLocalizedString("Unable to get location header.", comment: "")
         case .unableToOpenBrowser:
             return NSLocalizedString("Error triggering authorization flow in default system browser. NSWorkspace.openURL returned false.", comment: "")
-
+        case .errorUnarchivingStateManager(let storageKey):
+            return NSLocalizedString("Unarchived object for storage key \(storageKey) but could not cast to OktaOidcStateManager", comment: "")
         }
     }
 }

--- a/Sources/OktaOidc/Common/OktaOidcStateManager.swift
+++ b/Sources/OktaOidc/Common/OktaOidcStateManager.swift
@@ -308,3 +308,19 @@ private extension OktaOidcStateManager {
         })
     }
 }
+
+@objc public extension OktaOidcStateManager {
+    @objc class func throwingReadFromSecureStorage(for config: OktaOidcConfig) throws -> OktaOidcStateManager {
+        return try throwingReadFromSecureStorage(forKey: config.clientId)
+    }
+    
+    private class func throwingReadFromSecureStorage(forKey secureStorageKey: String) throws -> OktaOidcStateManager {
+        let encodedAuthState: Data = try OktaOidcKeychain.get(key: secureStorageKey)
+        prepareKeyedArchiver()
+        let anyState = try NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(encodedAuthState)
+        guard let state = anyState as? OktaOidcStateManager else {
+            throw OktaOidcError.errorUnarchivingStateManager(secureStorageKey)
+        }
+        return state
+    }
+}


### PR DESCRIPTION
We will have Pathway use our fork so we can use this method to see any specific failures that occur at this step (instead of Okta swallowing it)